### PR TITLE
[RFC/WIP] basic wrapping of enums for cpp.

### DIFF
--- a/src/wrap_cpp.jl
+++ b/src/wrap_cpp.jl
@@ -97,7 +97,6 @@ function emit(out::IO, parm::cindex.ParmDecl)
     modifs = function_arg_modifiers(parm)
     print(out, join(map(x->x.text, modifs), " "))
     space(out)
-
     emit(out, cu_type(parm))
 end
 
@@ -132,7 +131,7 @@ end
 # end
 
 
-function wrap(out::IO, method::cindex.CXXMethod, nameid::Int)
+function wrap(out::IO, method::cindex.CXXMethod, nameid::Int=0)
     buf = IOBuffer()
 
     # bail out if any argument is not supported
@@ -197,7 +196,7 @@ function wrap(out::IO, method::cindex.CXXMethod, nameid::Int)
 end
 
 
-function wrap(out::IO, method::cindex.Constructor, nameid::Int)
+function wrap(out::IO, method::cindex.Constructor, nameid::Int=0)
     buf = IOBuffer()
 
     # bail out if any argument is not supported
@@ -283,7 +282,7 @@ cl_to_c = {
     cindex.Float          => "float",
     cindex.Double         => "double",
     cindex.LongDouble     => "long double",
-    cindex.Enum           => "int",
+    cindex.Enum           => "unsigned int",
     cindex.NullPtr        => "NULL",
     cindex.UInt128        => "uint128_t",
     cindex.LValueReference=> "LVAL"
@@ -469,7 +468,7 @@ cl_to_jl = {
     cindex.Float            => :Cfloat,
     cindex.Double           => :Cdouble,
     cindex.LongDouble       => Float64,
-    cindex.Enum             => :Cint,
+    cindex.Enum             => :Cuint,
     cindex.NullPtr          => C_NULL,
     cindex.UInt128          => Uint128,
     cindex.FirstBuiltin     => Void,
@@ -514,5 +513,30 @@ function get_args(method::Union(cindex.CXXMethod, cindex.Constructor))
     end
     return args
 end
+
+#enums are passed through the C wrapper with no special sauce
+function wrap(buf::IO, cursor::EnumDecl, id::Int64=0; usename="")
+end
+
+#copy-pasted from wrap_c. TODO: unify
+function wrapjl(buf::IO, libname, cursor::EnumDecl, id::Int64=0; usename="")
+    if (usename == "" && (usename = get_name_namespace(cursor)) == "")
+        usename = name_anon()
+    end
+    enumname = usename
+    println(buf, "# begin enum $enumname")
+    print(buf, "typealias $enumname ")
+    wrapjl(buf, cindex.getEnumDeclIntegerType(cursor))
+    println(buf)
+    for enumitem in children(cursor)
+        #cur_name = string(enumname, "_", cindex.spelling(enumitem))
+        cur_name = cindex.spelling(enumitem)
+        if (length(cur_name) < 1) continue end
+
+        println(buf, "const ", cur_name, " = ", value(enumitem))
+    end
+    println(buf, "# end enum $enumname")
+end
+
 
 end # module wrap_cpp

--- a/test/cxx/enums.hh
+++ b/test/cxx/enums.hh
@@ -1,0 +1,6 @@
+class A {
+    public:
+    enum MyEnum {
+        x, y, z 
+    };
+};

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -1,0 +1,25 @@
+using Clang.cindex
+using Base.Test
+
+top = cindex.parse_header("cxx/enums.hh"; cplusplus = true)
+
+class = cindex.search(top, "A") |> first
+enum = cindex.search(class, "MyEnum") |> first
+
+Clang.wt.wrap(STDOUT, enum)
+buf = IOBuffer()
+Clang.wt.wrapjl(buf, :testlib, enum)
+s = takebuf_string(buf)
+
+for l in split(strip(s), "\n")
+    l = strip(l)
+    if !beginswith(l, "#")
+        println(l)
+        eval(parse(l))
+    end
+end
+
+@test A_MyEnum <: Uint32
+@test x == uint32(0)
+@test y == uint32(1)
+@test z == uint32(2)


### PR DESCRIPTION
Utilized the wrap_c wrap method for enums in wrap_cpp. In case the enum is a semantic child of a namespace or a class, the parentage is added to the Julia-wrapped enum name.

However, in cpp, casting an uint to an enum does not work, so presently, for the C-wrapper generation, one needs to find a way to get the fully-qualified name of the enum.
