### PR TITLE
Don't limit cursor headers to wc.headers

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -542,7 +542,6 @@ function wrap_header(wc::WrapContext, topcu::CLCursor, top_hdr, obuf::Array)
 
         if beginswith(cursor_name, "__")    ||      # skip compiler definitions
            cursor_name in wc.cache_wrapped  ||      # already wrapped
-           !(cursor_hdr in wc.headers)      || 
            !wc.cursor_wrapped(cursor_name, cursor)  # client callback
 
             continue


### PR DESCRIPTION
I'm about to wrap Freetype, where the recommended way of including is the following:

```
#include <ft2build.h>
#include FT_FREETYPE_H
```

I therefore can't add Freetype's headers directly to wc.headers. But as I understood it correctly that's what the function `header_wrapped` is for, which looks like this for me:

```
function should_wrap(hdr::ASCIIString, name::ASCIIString)
    return beginswith(dirname(name), FREETYPE_INCLUDE)
end
```

But because of the check for `cursor_hdr in wc.headers` I can't let wrap_c include the Freetype headers.
