### PR TITLE
Turn on tests in runtests.jl, and fix expr comparison in test/wrap_c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - sudo apt-get install libpcre3-dev julia -y
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Clang")'
+  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.build("Clang"); Pkg.test("Clang")'

--- a/src/wrap_cpp.jl
+++ b/src/wrap_cpp.jl
@@ -1,5 +1,5 @@
-# module wrap_cpp
-module wt
+module wrap_cpp
+# module wt
 
 using Clang.cindex
 using Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,5 @@
 using Clang
+
+include("cbasic.jl")
+include("functions.jl")
+include("wrap_c.jl")

--- a/test/strip_line_numbers.jl
+++ b/test/strip_line_numbers.jl
@@ -1,0 +1,17 @@
+strip_line_numbers!(arg) = arg
+function strip_line_numbers!(ex::Expr)
+    keep = trues(length(ex.args))
+    for i = 1:length(ex.args)
+        if isa(ex.args[i], LineNumberNode)
+            keep[i] = false
+        end
+        isa(ex.args[i], Expr) || continue
+        if ex.args[i].head == :line
+            keep[i] = false
+        else
+            ex.args[i] = strip_line_numbers!(ex.args[i])
+        end
+    end
+    ex.args = ex.args[keep]
+    ex
+end

--- a/test/wrap_c.jl
+++ b/test/wrap_c.jl
@@ -11,9 +11,25 @@ buf = Any[]
 
 wrap_c.wrap(wc, buf, func1, "test")
 
-@test buf[1] == quote
+exc = :(
     function func1(a::Cint,b::Cdouble,c::Ptr{Cdouble},d::Ptr{Void})
         ccall((:func1,test),Cint,(Cint,Cdouble,Ptr{Cdouble},Ptr{Void}),a,b,c,d)
+    end)
+
+strip_line_numbers!(arg) = arg
+function strip_line_numbers!(ex::Expr)
+    keep = trues(length(ex.args))
+    for i = 1:length(ex.args)
+        isa(ex.args[i], Expr) || continue
+        if ex.args[i].head == :line
+            keep[i] = false
+        else
+            strip_line_numbers!(ex.args[i])
+        end
     end
+    ex.args = ex.args[keep]
 end
 
+strip_line_numbers!(exc)
+
+@test buf[1] == exc

--- a/test/wrap_c.jl
+++ b/test/wrap_c.jl
@@ -1,5 +1,6 @@
 using Base.Test
 using Clang.wrap_c
+include("strip_line_numbers.jl")
 
 wc = wrap_c.init(;  headers = ["cxx/cbasic.h"])
 hdr_tunits = wrap_c.parse_c_headers(wc)
@@ -15,20 +16,6 @@ exc = :(
     function func1(a::Cint,b::Cdouble,c::Ptr{Cdouble},d::Ptr{Void})
         ccall((:func1,test),Cint,(Cint,Cdouble,Ptr{Cdouble},Ptr{Void}),a,b,c,d)
     end)
-
-strip_line_numbers!(arg) = arg
-function strip_line_numbers!(ex::Expr)
-    keep = trues(length(ex.args))
-    for i = 1:length(ex.args)
-        isa(ex.args[i], Expr) || continue
-        if ex.args[i].head == :line
-            keep[i] = false
-        else
-            strip_line_numbers!(ex.args[i])
-        end
-    end
-    ex.args = ex.args[keep]
-end
 
 strip_line_numbers!(exc)
 


### PR DESCRIPTION
This also adds `Pkg.build("Clang")` to the tests.

One more issue, though: I'm not sure if the version of julia on travis was built with `BUILD_LLVM_CLANG=1`.