### PR TITLE
Prevent overwriting structs with typedefs

### DIFF
--- a/src/cindex.jl
+++ b/src/cindex.jl
@@ -47,6 +47,9 @@ function parse_header(header::String;
                 args                            = ASCIIString[""],
                 includes                        = ASCIIString[],
                 flags                           = TranslationUnit_Flags.None)
+    if !isfile(header)
+        error(header, " not found")
+    end
     if (index == None)
         index = idx_create(0, (diagnostics ? 1 : 0))
     end

--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -734,7 +734,7 @@ function dump_to_buf(expr_buf::OrderedDict{Symbol, ExprUnit})
     buf
 end
 
-function run(wc::WrapContext) 
+function Base.run(wc::WrapContext)
     # Parse headers
     parsed = parse_c_headers(wc)
     # Sort includes by requirement order
@@ -777,10 +777,7 @@ function run(wc::WrapContext)
 end
 
 # Deprecated interface
-wrap_c_headers(wc::WrapContext, headers) = begin
-    warn("wrap_c_headers: deprecated")
-    wc.headers = headers; run(wc)
-end
+@deprecate wrap_c_headers(wc::WrapContext, headers)   (wc.headers = headers; run(wc))
 
 ###############################################################################
 # Utilities

--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -38,8 +38,11 @@ type ExprUnit
     state::Symbol
 end
 
+immutable Poisoned
+end
+
 ExprUnit() = ExprUnit(Any[], OrderedSet{Symbol}(), :new)
-ExprUnit(e::Union(Expr,Symbol,ASCIIString), deps=Any[]; state::Symbol=:new) = ExprUnit(Any[e], OrderedSet{Symbol}([target_type(dep) for dep in deps]...), state)
+ExprUnit(e::Union(Expr,Symbol,ASCIIString,Poisoned), deps=Any[]; state::Symbol=:new) = ExprUnit(Any[e], OrderedSet{Symbol}([target_type(dep) for dep in deps]...), state)
 ExprUnit(a::Array, deps=Any[]; state::Symbol=:new) = ExprUnit(a, OrderedSet{Symbol}([target_type(dep) for dep in deps]...), state)
 
 ### WrapContext
@@ -402,6 +405,7 @@ function wrap(context::WrapContext, expr_buf::OrderedDict, sd::StructDecl; usena
         if (isa(cu, StructDecl) || isa(cu, UnionDecl))
             continue
         elseif !(isa(cu, FieldDecl) || isa(cu, TypeRef))
+            expr_buf[usesym] = ExprUnit(Poisoned())
             warn("Skipping struct: \"$usename\" due to unsupported field: $cur_name")
             return
         elseif (length(cur_name) < 1)
@@ -475,7 +479,9 @@ function wrap(context::WrapContext, expr_buf::OrderedDict, tdecl::TypedefDecl; u
 
     td_sym = symbol(spelling(tdecl))
     td_target = repr_jl(td_type)
-    expr_buf[td_sym] = ExprUnit(Expr(:typealias, td_sym, td_target), Any[td_target])
+    if !haskey(expr_buf, td_sym)
+        expr_buf[td_sym] = ExprUnit(Expr(:typealias, td_sym, td_target), Any[td_target])
+    end
 end
 
 ################################################################################
@@ -679,6 +685,7 @@ function print_buffer(ostrm, obuf)
     in_enum = false
 
     for e in obuf
+        isa(e, Poisoned) && continue
         prev_state = state
         if state != :enum
             state = (isa(e, String) ? :string :

--- a/test/cxx/c_struct_typedef.h
+++ b/test/cxx/c_struct_typedef.h
@@ -1,0 +1,14 @@
+struct Str
+{
+  int x;
+};
+
+typedef struct Str Str;
+
+/* If this remains unparseable, char2 should be omitted from the file */
+struct __attribute__((aligned(2))) char2
+{
+  signed char x,y;
+};
+
+typedef struct char2 char2;

--- a/test/wrap_struct_typedef.jl
+++ b/test/wrap_struct_typedef.jl
@@ -1,0 +1,13 @@
+using Base.Test
+using Clang.wrap_c
+
+headername = "cxx/c_struct_typedef.h"
+wc = wrap_c.init(;  headers = [headername], header_wrapped=(a,b)->true)
+parsed = wrap_c.parse_c_headers(wc)
+obuf = wc.output_bufs[headername]
+wrap_c.wrap_header(wc, parsed[headername], headername, obuf)
+common_buf = wrap_c.dump_to_buf(wc.common_buf)
+io = IOBuffer()
+wrap_c.print_buffer(io, common_buf)
+str = takebuf_string(io)
+@test str == "\ntype Str\n    x::Cint\nend\n"


### PR DESCRIPTION
This addresses some problems I encountered in wrapping CUDA6.5. I was finding that a struct definition, followed by a typedef with the same name, would result in the trivial `typealias dim3 dim3` being written to the common.jl file.