### PR TITLE
I can haz continuous integration?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     #- JULIAVERSION="juliareleases"
     - JULIAVERSION="julianightlies"
 before_install:
+  - export LD_LIBRARY_PATH=/usr/lib/llvm-3.3/lib
   # Clang.jl
   - sudo apt-get install libclang-3.3 libclang-3.3-dev llvm-3.3 libllvm3.3
   # Julia test setup

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.4-
 Compat
 DataStructures

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ if !haskey(ENV, "LLVM_CONFIG") ENV["LLVM_CONFIG"] = find_llvm() end
 
 # on travis and some other systems, the llvm lib may not be in the
 # default path.
-push!(DL_LOAD_PATH, readchomp(`$(ENV["LLVM_CONFIG"]) --libdir`))
+push!(Libdl.DL_LOAD_PATH, readchomp(`$(ENV["LLVM_CONFIG"]) --libdir`))
 
 cd(joinpath(Pkg.dir(), "Clang", "deps", "src") )
 run(`make`)
@@ -22,4 +22,4 @@ if (!ispath("../usr/lib"))
   run(`mkdir ../usr/lib`)
 end
 
-run(`mv libwrapclang.$(Base.Sys.shlib_ext) ../usr/lib`)
+run(`mv libwrapclang.$(Libdl.dlext) ../usr/lib`)

--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -1,5 +1,5 @@
 if haskey(ENV, "TRAVIS")
-    push!(DL_LOAD_PATH, "/usr/lib/llvm-3.3/lib")
+    push!(Libdl.DL_LOAD_PATH, "/usr/lib/llvm-3.3/lib")
     const libwci = joinpath(Pkg.dir("Clang","deps","usr","lib"), "libwrapclang.so")
 else
     const libwci = find_library(["libwrapclang",],[Pkg.dir("Clang", "deps", "usr", "lib"),])

--- a/src/util.jl
+++ b/src/util.jl
@@ -10,7 +10,7 @@ function find_sym(name,liblist)
     dl = C_NULL
     for dl in keys(libs)
         try
-            dlsym_e(dl, name)
+            Libdl.dlsym_e(dl, name)
         catch
             continue
         end


### PR DESCRIPTION
FYI: also bumps REQUIRE to 0.4. I hope this won't be a problem for package authors as long as the output remains backward-compatible with 0.3. Moving to 0.4 will let me rewrite the libclang interface to use byval structs instead of the nasty memcpy hack. This should improve maintainability, and get us any improvements made to libclang since llvm 3.1 (once the interface is self-regenerating).