### PR TITLE
support UTF8 headers paths

### DIFF
--- a/src/cindex.jl
+++ b/src/cindex.jl
@@ -350,7 +350,7 @@ function tu_cursor(tu::CXTranslationUnit)
 end
  
 function tu_parse(CXIndex,
-                  source_filename::ASCIIString, 
+                  source_filename::AbstractString, 
                   cl_args::Array{ASCIIString,1},
                   num_clargs,
                   unsaved_files::CXUnsavedFile,


### PR DESCRIPTION
joinpath may return a utf8 string in many cases, it's nice to allow it to be supported here