### PR TITLE
Use relative path and `@__FILE__` instead of `Pkg.dir`

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,13 +13,13 @@ if !haskey(ENV, "LLVM_CONFIG") ENV["LLVM_CONFIG"] = find_llvm() end
 # default path.
 push!(Libdl.DL_LOAD_PATH, readchomp(`$(ENV["LLVM_CONFIG"]) --libdir`))
 
-cd(joinpath(Pkg.dir(), "Clang", "deps", "src") )
+cd(joinpath(dirname(@__FILE__), "src"))
 run(`make`)
-if (!ispath("../usr")) 
-  run(`mkdir ../usr`)
+if (!ispath("../usr"))
+    run(`mkdir ../usr`)
 end
-if (!ispath("../usr/lib")) 
-  run(`mkdir ../usr/lib`)
+if (!ispath("../usr/lib"))
+    run(`mkdir ../usr/lib`)
 end
 
 run(`mv libwrapclang.$(Libdl.dlext) ../usr/lib`)

--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -1,7 +1,10 @@
 if haskey(ENV, "TRAVIS")
     push!(Libdl.DL_LOAD_PATH, "/usr/lib/llvm-3.3/lib")
-    const libwci = joinpath(Pkg.dir("Clang","deps","usr","lib"), "libwrapclang.so")
+    const libwci = joinpath(dirname(@__FILE__),
+                            "usr", "lib" , "libwrapclang.so")
 else
-    const libwci = Libdl.find_library(["libwrapclang",],[Pkg.dir("Clang", "deps", "usr", "lib"),])
+    const libwci = Libdl.find_library(["libwrapclang",],
+                                      [joinpath(dirname(@__FILE__),
+                                                "usr", "lib")])
     @assert(libwci != "", "Failed to find required library libwrapclang. Try re-running the package script using Pkg.build(\"Clang\")")
 end

--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -335,7 +335,7 @@ function wrap(context::WrapContext, buf::Array, func_decl::FunctionDecl, libname
     func_type = cindex.cu_type(func_decl)
     if isa(func_type, FunctionNoProto)
         warn("No Prototype for $(func_decl) - assuming no arguments")
-	elseif cindex.isFunctionTypeVariadic(func_type) == 1
+    elseif cindex.isFunctionTypeVariadic(func_type) == 1
         warn("Skipping VarArg Function $(func_decl)")
         return
     end

--- a/test/cbasic.jl
+++ b/test/cbasic.jl
@@ -1,7 +1,7 @@
 using Clang.cindex
 using Base.Test
 
-top = cindex.parse_header("cxx/cbasic.h",
+top = cindex.parse_header(joinpath(dirname(@__FILE__), "cxx/cbasic.h"),
                           flags = TranslationUnit_Flags.DetailedPreprocessingRecord |
                           TranslationUnit_Flags.SkipFunctionBodies)
 

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,7 +1,8 @@
 using Clang.cindex
 using Base.Test
 
-top = cindex.parse_header("cxx/cxxbasic.h"; cplusplus = true)
+top = cindex.parse_header(joinpath(dirname(@__FILE__), "cxx/cxxbasic.h");
+                          cplusplus = true)
 
 funcs = cindex.search(top, "func")
 @test length(funcs) == 1

--- a/test/wrap_c.jl
+++ b/test/wrap_c.jl
@@ -2,11 +2,11 @@ using Base.Test
 using Clang.wrap_c
 include("strip_line_numbers.jl")
 
-wc = wrap_c.init(;  headers = ["cxx/cbasic.h"])
+wc = wrap_c.init(;  headers = [joinpath(dirname(@__FILE__), "cxx/cbasic.h")])
 hdr_tunits = wrap_c.parse_c_headers(wc)
 
 # test func1
-tunit = hdr_tunits["cxx/cbasic.h"]
+tunit = hdr_tunits[joinpath(dirname(@__FILE__), "cxx/cbasic.h")]
 func1 = search(tunit, "func1")[1]
 buf = Any[]
 


### PR DESCRIPTION
In order to support installing outside `.julia`. Either for system wise install or for developing outside `.julia`.

Also includes a few whitespace fixes.
