### PR TITLE
Fix deprecation warnings and breakage caused by #137

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,4 @@
-if VERSION >= v"0.4.0-dev+6521"
-    using Base.Libdl
-    dlext = Base.Libdl.dlext
-else
-    dlext = Base.Sys.shlib_ext
-end
+#
 
 find_llvm() = begin
     if haskey(ENV, "TRAVIS")
@@ -29,4 +24,4 @@ if (!ispath("../usr/lib"))
     run(`mkdir ../usr/lib`)
 end
 
-run(`mv libwrapclang.$(dlext) ../usr/lib`)
+run(`mv libwrapclang.$(Libdl.dlext) ../usr/lib`)

--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -1,13 +1,10 @@
-
 if haskey(ENV, "TRAVIS")
     push!(Libdl.DL_LOAD_PATH, "/usr/lib/llvm-3.3/lib")
     const libwci = joinpath(dirname(@__FILE__),
                             "usr", "lib" , "libwrapclang.so")
 else
-  if VERSION > v"0.4-"
-    const libwci = Base.Libdl.find_library(["libwrapclang",],[Pkg.dir("Clang", "deps", "usr", "lib"),])
-  else
-    const libwci = find_library(["libwrapclang",],[Pkg.dir("Clang", "deps", "usr", "lib"),])
-  end
+    const libwci = Libdl.find_library(["libwrapclang",],
+                                      [joinpath(dirname(@__FILE__),
+                                                "usr", "lib")])
     @assert(libwci != "", "Failed to find required library libwrapclang. Try re-running the package script using Pkg.build(\"Clang\")")
 end

--- a/examples/parsing_c_with_clangjl/notebook.ipynb
+++ b/examples/parsing_c_with_clangjl/notebook.ipynb
@@ -331,15 +331,15 @@
       "printobj(t::cindex.Pointer)            = cindex.pointee_type(t)\n",
       "printobj(ind::Int, t::cindex.CLType)   = printind(ind, printobj(t))\n",
       "\n",
-      "function printobj(ind::Int, cursor::Union(cindex.FieldDecl, cindex.ParmDecl))\n",
+      "function printobj(ind::Int, cursor::Union{cindex.FieldDecl, cindex.ParmDecl})\n",
       "    printind(ind+1, typeof(cursor), \" \", printobj(cu_type(cursor)), \" \", name(cursor))\n",
       "end\n",
       "\n",
-      "function printobj(ind::Int, node::Union(cindex.CLCursor,\n",
+      "function printobj(ind::Int, node::Union{cindex.CLCursor,\n",
       "                                        cindex.StructDecl,\n",
       "                                        cindex.CompoundStmt,\n",
       "                                        cindex.FunctionDecl,\n",
-      "                                        cindex.BinaryOperator) )\n",
+      "                                        cindex.BinaryOperator} )\n",
       "    printind(ind, \" \", typeof(node), \" \", name(node))\n",
       "    for c in children(node)\n",
       "        printobj(ind + 1, c)\n",
@@ -444,10 +444,10 @@
      "source": [
       "Note that a generic `printobj` function has been defined for the abstract *CLType* and *CLCursor* types, and multiple dispatch is used to define the printers for various specific types needing custom behavior. In particular, the following function handles all cursor types for which recursive printing of child nodes is required:\n",
       "\n",
-      "    function printobj(ind::Int, node::Union(cindex.CLCursor,\n",
+      "    function printobj(ind::Int, node::Union{cindex.CLCursor,\n",
       "                                            cindex.StructDecl,\n",
       "                                            cindex.CompoundStmt,\n",
-      "                                            cindex.FunctionDecl) )"
+      "                                            cindex.FunctionDecl} )"
      ]
     },
     {

--- a/src/cindex.jl
+++ b/src/cindex.jl
@@ -128,7 +128,7 @@ function resolve_type(rt::CLType)
     return rt
 end
 
-function return_type(c::Union(FunctionDecl, CXXMethod), resolve::Bool)
+function return_type(c::Union{FunctionDecl, CXXMethod}, resolve::Bool)
     if (resolve)
         return resolve_type( getCursorResultType(c) )
     else
@@ -243,14 +243,14 @@ end
 ################################################################################
 
 # Retrieve function arguments for a given cursor
-function function_args(cursor::Union(FunctionDecl, CXXMethod))
+function function_args(cursor::Union{FunctionDecl, CXXMethod})
     search(cursor, ParmDecl)
 end
 
 
 #returns a tuple with the default argument values for a C++ function
 #only seems to work if cplusplus=true in parse_header
-function function_arg_defaults(method::Union(cindex.CXXMethod, cindex.FunctionDecl, cindex.Constructor))
+function function_arg_defaults(method::Union{cindex.CXXMethod, cindex.FunctionDecl, cindex.Constructor})
     defvals = Any[]
     for c in children(method)
         if isa(c,cindex.ParmDecl)
@@ -289,7 +289,7 @@ function function_arg_defaults(method::Union(cindex.CXXMethod, cindex.FunctionDe
 end
 
 #returns an array of the function return type modifiers
-function function_return_modifiers(f::Union(FunctionDecl, CXXMethod))
+function function_return_modifiers(f::Union{FunctionDecl, CXXMethod})
     modifs = Any[]
     for tok in tokenize(f)
         if isa(tok, cindex.Keyword)

--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -41,7 +41,7 @@ immutable Poisoned
 end
 
 ExprUnit() = ExprUnit(Any[], OrderedSet{Symbol}(), :new)
-ExprUnit(e::Union(Expr,Symbol,ASCIIString,Poisoned), deps=Any[]; state::Symbol=:new) = ExprUnit(Any[e], OrderedSet{Symbol}([target_type(dep) for dep in deps]), state)
+ExprUnit(e::Union{Expr,Symbol,ASCIIString,Poisoned}, deps=Any[]; state::Symbol=:new) = ExprUnit(Any[e], OrderedSet{Symbol}([target_type(dep) for dep in deps]), state)
 ExprUnit(a::Array, deps=Any[]; state::Symbol=:new) = ExprUnit(a, OrderedSet{Symbol}([target_type(dep) for dep in deps]), state)
 
 ### WrapContext
@@ -207,7 +207,7 @@ int_conversion = Dict{Any,Any}(
 #
 ################################################################################
 
-function repr_jl(t::Union(cindex.Record, cindex.Typedef))
+function repr_jl(t::Union{cindex.Record, cindex.Typedef})
     tname = symbol(spelling(cindex.getTypeDeclaration(t)))
     return get(cl_to_jl, tname, tname)
 end

--- a/src/wrap_cpp.jl
+++ b/src/wrap_cpp.jl
@@ -76,7 +76,7 @@ function emit(out::IO, t::CLType)
     end
 end
 
-function emit(out::IO, t::Union(Record, Typedef))
+function emit(out::IO, t::Union{Record, Typedef})
     print(out, spelling(cindex.getTypeDeclaration(t)))
 end
 
@@ -307,7 +307,7 @@ function wrapjl(out::IO, t::cindex.ConstantArray)
     print(out, "FIXEDARRAY")
 end
 
-function wrapjl(out::IO, t::Union(cindex.Record, cindex.Typedef))
+function wrapjl(out::IO, t::Union{cindex.Record, cindex.Typedef})
     print(out, spelling(cindex.getTypeDeclaration(t)))
 end
 
@@ -505,7 +505,7 @@ function returns_value(rtype::CLType)
     return hasret
 end
 
-function get_args(method::Union(cindex.CXXMethod, cindex.Constructor))
+function get_args(method::Union{cindex.CXXMethod, cindex.Constructor})
     args = CLCursor[]
     for c in children(method)
         if isa(c,cindex.ParmDecl)


### PR DESCRIPTION
* Revert 2 useless changes in #137 
* `Union()` -> `Union{}`
