### PR TITLE
RFC: Generate safer wrapper function

### DIFF
--- a/test/wrap_c.jl
+++ b/test/wrap_c.jl
@@ -13,7 +13,7 @@ buf = Any[]
 wrap_c.wrap(wc, buf, func1, "test")
 
 exc = :(
-    function func1(a::Cint,b::Cdouble,c::Ptr{Cdouble},d::Ptr{Void})
+    function func1(a::Cint,b::Cdouble,c,d)
         ccall((:func1,test),Cint,(Cint,Cdouble,Ptr{Cdouble},Ptr{Void}),a,b,c,d)
     end)
 


### PR DESCRIPTION
* Remove type constraint in the wrapper so that it is compatible with the
  `ccall` GC root mechanism.
* Map `char*` to `Cstring` and `wchar_t*` to `Cwstring`

Closes https://github.com/ihnorton/Clang.jl/issues/152
