### PR TITLE
Optimistically create unions.

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -322,6 +322,11 @@ function largestfield(cu::UnionDecl)
             maxelem = i
         end
     end
+    if maxelem == 0
+        warn("  all field sizes are unknown.")
+        maxelem = 1
+    end
+
     fields[maxelem]
 end
 


### PR DESCRIPTION
Without this Clang.jl fails to generate code for the `VkClearValue` as defined below. The problem is that both member sizes are unkown and thus equal to zero leading to an IndexOutOfBound error.

``` C
#include <stdint.h>

typedef union VkClearColorValue {
    float       float32[4];
    int32_t     int32[4];
    uint32_t    uint32[4];
} VkClearColorValue;

typedef struct VkClearDepthStencilValue {
    float       depth;
    uint32_t    stencil;
} VkClearDepthStencilValue;

typedef union VkClearValue {
    VkClearColorValue           color;
    VkClearDepthStencilValue    depthStencil;
} VkClearValue;
```
