### PR TITLE
Handling literals, fixes #158

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -529,7 +529,7 @@ end
 
 function handle_macro_exprn(tokens::TokenList, pos::Int)
     function trans(tok)
-        ops = ["+" "-" "*" ">>" "<<" "/" "\\" "%" "|" "||" "^" "&" "&&"]
+        ops = ["+" "-" "*" "~" ">>" "<<" "/" "\\" "%" "|" "||" "^" "&" "&&"]
         if (isa(tok, cindex.Literal) ||
             (isa(tok,cindex.Identifier))) return 0
         elseif (isa(tok, cindex.Punctuation) && tok.text in ops) return 1


### PR DESCRIPTION
In order to fix #158 correctly I added `~` to the list of valid identifiers. But there is also type information present that is needed for `~` to work correctly. 

```C
#define VK_REMAINING_MIP_LEVELS           (~0U)
```

is now turned into:
```julia
const VK_REMAINING_MIP_LEVELS = ~(UInt32(0))
```

see: https://github.com/JuliaGPU/Vulkan.jl/pull/3/commits/d268b6b2022352a8409b9bc6e0f44e5849c39c01 for an example.