### PR TITLE
OSX: Let Homebrew install llvm automatically

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.4
+julia 0.5-
 DataStructures
 Compat 0.8.0
+@osx Homebrew 0.3.4


### PR DESCRIPTION
This PR is an attempt to fix #165 by using Homebrew.jl to install `llvm`
automatically in user space if `which llvm-config` does not pick up an
existing installation of LLVM.

The main change is to now load Homebrew.jl on OSX every time
`Pkg.build("Clang")` runs, and if no system installation of LLVM could
be found, uses a user space `llvm` keg (installing it as necessary).

Summary of other changes:

- Introduces Homebrew as an OSX-specific dependency
- Add short documentation of `find_llvm()` in `deps/build.jl`.
  `find_llvm()` now consistently returns an error if none of the
  `which llvm-config` invocations return useful information.
  Currently, `find_llvm()` can simply return `false` on the last line,
  which poisons the rest of the build script.