### PR TITLE
Minimal changes to support wrapping of igraph

### DIFF
--- a/src/cindex.jl
+++ b/src/cindex.jl
@@ -221,7 +221,11 @@ endof(tl::TokenList) = length(tl)
 done(tl::TokenList, i) = (i > length(tl))
 
 function getindex(tl::TokenList, i::Int)
-    if (i < 1 || i > length(tl)) throw(BoundsError()) end
+    if (i < 1 || i > length(tl))
+        # throw(BoundsError())
+        warn("TokenList miss at index ", i)
+        return Comment(string("TokenList miss at index ", i))
+    end
 
     c = CXToken(unsafe_load(tl.ptr, i))
     kind = c.data[1].int_data1
@@ -314,8 +318,7 @@ function function_arg_modifiers(p::ParmDecl)
         #read up to variable identifier
         isa(tok, cindex.Identifier) && break
 
-        const tt = tok.text
-        if tt in ["const", "virtual"]
+        if tok.text in ["const", "virtual"]
             push!(modifs, tok)
         end
     end

--- a/src/cindex/defs.jl
+++ b/src/cindex/defs.jl
@@ -338,6 +338,17 @@ baremodule TypeKind
     const ConstantArray = 112
     const CLVector = 113
     const IncompleteArray = 114
+    const VariableArray = 115
+    const DependentSizedArray = 116
+    const MemberPointer = 117
+    const Auto = 118
+
+    #=
+    * \brief Represents a type that was referred to using an elaborated type keyword.
+    *
+    * E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+    =#
+    const CXType_Elaborated = 119
 end
 baremodule CallingConv
     const Default = 0

--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -167,7 +167,11 @@ cl_to_jl = Dict{Any,Any}(
     cindex.Int128           => :UInt128,
 
     cindex.FirstBuiltin     => :Void,
+    cindex.CXType_Elaborated => :Void,
     cindex.Complex          => :Complex,
+    cindex.BlockPointer     => :Void,
+    cindex.Pointer          => :Void,
+    cindex.Invalid          => :Void,
     :size_t                 => :Csize_t,
     :ptrdiff_t              => :Cptrdiff_t,
     :uint64_t               => :UInt64,

--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -124,7 +124,7 @@ function init(;
                                  cursor_wrapped,
                                  OrderedDict{Symbol,ExprUnit}(),
                                  Set{Compat.ASCIIString}(),
-                                 DefaultOrderedDict(Compat.ASCIIString, Array{Any}, ()->Any[]),
+                                 DefaultOrderedDict{Compat.ASCIIString, Array{Any}}(()->Any[]),
                                  options,
                                  0,
                                  rewriter)


### PR DESCRIPTION
Definitely closes #176, may also close #129 (since I saw the same message and subsequently added `cindex.Invalid` to `cl_to_jl` list.) Fix one deprecation warning on v0.5 as well.