### PR TITLE
Restore an orphan commit from the v0.0.4 tag

### DIFF
--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -5,3 +5,7 @@ else
     const libwci = find_library(["libwrapclang",],[Pkg.dir("Clang", "deps", "usr", "lib"),])
     @assert(libwci != "", "Failed to find required library libwrapclang. Try re-running the package script using Pkg.build(\"Clang\")")
 end
+
+println("libwci: ", libwci)
+println("DLLP: ", DL_LOAD_PATH)
+run(`bash -c "ls /usr/lib/llvm-3.3/lib/libclang*"`)


### PR DESCRIPTION
Doing some scraping of metadata, found that the v0.0.4 tag of Clang is the below orphaned commit, it's not in the history of any branches and wasn't pushed as a git tag. I don't actually want anyone to merge this, but just so this commit can be checked out without getting a "fatal: reference is not a tree" error, it would be good if someone with commit access could do
```
git remote add tkelman https://github.com/tkelman/Clang.jl
git fetch tkelman
git checkout c4d18994e7b4f6a5d8de6f88eea681639528a74a
git tag v0.0.4
git push origin v0.0.4
```

That is all, if someone does that, we can go ahead and close this. Thanks!