### PR TITLE
Improve tokenize, uncap REQUIRE and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Here is a simple example:
 ```julia
 using Clang
 
+# LIBCLANG_HEADERS are those headers to be wrapped.
 const LIBCLANG_INCLUDE = joinpath(@__DIR__, "..", "deps", "usr", "include", "clang-c") |> normpath
 const LIBCLANG_HEADERS = [joinpath(LIBCLANG_INCLUDE, header) for header in readdir(LIBCLANG_INCLUDE) if endswith(header, ".h")]
 
-wc = init(; headers = CLANG_HEADERS,
+wc = init(; headers = LIBCLANG_HEADERS,
             output_file = joinpath(@__DIR__, "libclang_api.jl"),
             common_file = joinpath(@__DIR__, "libclang_common.jl"),
-            clang_includes = vcat(LIBCLANG_INCLUDE, LLVM_INCLUDE),
+            clang_includes = vcat(LIBCLANG_INCLUDE, CLANG_INCLUDE),
             clang_args = ["-I", joinpath(LIBCLANG_INCLUDE, "..")],
             header_wrapped = (root, current)->root == current,
             header_library = x->"libclang",
@@ -53,7 +54,7 @@ run(wc)
 #### Backward compatibility
 If you miss those old behaviors before v0.8, you could simply make the following change in your old generator script:
 ```julia
-using Clang: LLVM_INCLUDE
+using Clang: CLANG_INCLUDE
 using Clang.Deprecated.wrap_c
 using Clang.Deprecated.cindex
 ```
@@ -78,7 +79,7 @@ ctx = DefaultContext()
 # parse headers
 parse_headers!(ctx, LIBCLANG_HEADERS,
                args=["-I", joinpath(LIBCLANG_INCLUDE, "..")],
-               includes=vcat(LIBCLANG_INCLUDE, LLVM_INCLUDE),
+               includes=vcat(LIBCLANG_INCLUDE, CLANG_INCLUDE),
                )
 
 # settings

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 1.0.0 1.1.0-
+julia 1.0.0
 DataStructures
 BinaryProvider 0.3.0

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,7 +33,7 @@ const LIBCLANG_HEADERS = [joinpath(LIBCLANG_INCLUDE, header) for header in readd
 wc = init(; headers = CLANG_HEADERS,
             output_file = joinpath(@__DIR__, "libclang_api.jl"),
             common_file = joinpath(@__DIR__, "libclang_common.jl"),
-            clang_includes = vcat(LIBCLANG_INCLUDE, LLVM_INCLUDE),
+            clang_includes = vcat(LIBCLANG_INCLUDE, CLANG_INCLUDE),
             clang_args = ["-I", joinpath(LIBCLANG_INCLUDE, "..")],
             header_wrapped = (root, current)->root == current,
             header_library = x->"libclang",
@@ -46,7 +46,7 @@ run(wc)
 ### Backward compatibility
 If you miss those old behaviors before v0.8, you could simply make the following change in your old generator script:
 ```julia
-using Clang: LLVM_INCLUDE
+using Clang: CLANG_INCLUDE
 using Clang.Deprecated.wrap_c
 using Clang.Deprecated.cindex
 ```
@@ -71,7 +71,7 @@ ctx = DefaultContext()
 # parse headers
 parse_headers!(ctx, LIBCLANG_HEADERS,
                args=["-I", joinpath(LIBCLANG_INCLUDE, "..")],
-               includes=vcat(LIBCLANG_INCLUDE, LLVM_INCLUDE),
+               includes=vcat(LIBCLANG_INCLUDE, CLANG_INCLUDE),
                )
 
 # settings

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -9,7 +9,7 @@ ctx = DefaultContext()
 # parse headers
 parse_headers!(ctx, LIBCLANG_HEADERS,
                args=["-I", joinpath(LIBCLANG_INCLUDE, "..")],
-               includes=vcat(LIBCLANG_INCLUDE, LLVM_INCLUDE),
+               includes=vcat(LIBCLANG_INCLUDE, CLANG_INCLUDE),
                )
 
 # settings

--- a/src/Clang.jl
+++ b/src/Clang.jl
@@ -38,7 +38,7 @@ export pointee_type, argtype, element_type, element_num
 export resolve_type, get_named_type
 
 include("token.jl")
-export tokenize
+export TokenList, tokenize, annotate
 
 include("show.jl")
 

--- a/src/Clang.jl
+++ b/src/Clang.jl
@@ -76,8 +76,9 @@ end
 const LLVM_VERSION = match(r"[0-9]+.[0-9]+.[0-9]+", version()).match
 const LLVM_LIBDIR = joinpath(@__DIR__, "..", "deps", "usr", "lib") |> normpath
 const LLVM_INCLUDE = joinpath(LLVM_LIBDIR, "clang", LLVM_VERSION, "include")
+const CLANG_INCLUDE = LLVM_INCLUDE
 
-export LLVM_VERSION, LLVM_LIBDIR, LLVM_INCLUDE
+export LLVM_VERSION, LLVM_LIBDIR, LLVM_INCLUDE, CLANG_INCLUDE
 
 include("deprecated/Deprecated.jl")
 

--- a/src/cltypes.jl
+++ b/src/cltypes.jl
@@ -54,9 +54,12 @@ for sym in enum_names(CXTokenKind)
     clsym = split(string(sym), '_', limit=2) |> last |> Symbol
     @eval begin
         struct $clsym <: CLToken
+            token::CXToken
             kind::CXTokenKind
             text::String
         end
         CLTokenMap[$sym] = $clsym
     end
 end
+
+Base.convert(::Type{CXToken}, x::T) where {T<:CLToken} = x.token

--- a/src/token.jl
+++ b/src/token.jl
@@ -93,23 +93,26 @@ Return a TokenList from the given cursor.
 """
 function tokenize(c::CXCursor)
     tu = clang_Cursor_getTranslationUnit(c)
-    source_range = clang_getCursorExtent(c)
-    range_start = clang_getRangeStart(source_range)
-    range_end = clang_getRangeEnd(source_range)
+    GC.@preserve tu begin
+        source_range = clang_getCursorExtent(c)
+        range_start = clang_getRangeStart(source_range)
+        range_end = clang_getRangeEnd(source_range)
 
-    file = Ref{CXFile}(C_NULL)
-    start_line = Ref{Cuint}(0)
-    end_line = Ref{Cuint}(0)
-    start_column = Ref{Cuint}(0)
-    end_column = Ref{Cuint}(0)
-    offset = Ref{Cuint}(0)
-    clang_getExpansionLocation(range_start, file, start_line, start_column, offset)
-    clang_getExpansionLocation(range_end, file, end_line, end_column, offset)
+        file = Ref{CXFile}(C_NULL)
+        start_line = Ref{Cuint}(0)
+        end_line = Ref{Cuint}(0)
+        start_column = Ref{Cuint}(0)
+        end_column = Ref{Cuint}(0)
+        offset = Ref{Cuint}(0)
+        clang_getExpansionLocation(range_start, file, start_line, start_column, offset)
+        clang_getExpansionLocation(range_end, file, end_line, end_column, offset)
 
-    expanded_start = clang_getLocation(tu, file[], start_line[], start_column[])
-    expanded_end = clang_getLocation(tu, file[], end_line[], end_column[])
-    expanded_range = clang_getRange(expanded_start, expanded_end)
-    return TokenList(tu, expanded_range)
+        expanded_start = clang_getLocation(tu, file[], start_line[], start_column[])
+        expanded_end = clang_getLocation(tu, file[], end_line[], end_column[])
+        expanded_range = clang_getRange(expanded_start, expanded_end)
+        list = TokenList(tu, expanded_range)
+    end
+    return list
 end
 tokenize(c::CLCursor) = tokenize(c.cursor)
 

--- a/src/token.jl
+++ b/src/token.jl
@@ -93,8 +93,23 @@ Return a TokenList from the given cursor.
 """
 function tokenize(c::CXCursor)
     tu = clang_Cursor_getTranslationUnit(c)
-    sourcerange = clang_getCursorExtent(c)
-    return TokenList(tu, sourcerange)
+    source_range = clang_getCursorExtent(c)
+    range_start = clang_getRangeStart(source_range)
+    range_end = clang_getRangeEnd(source_range)
+
+    file = Ref{CXFile}(C_NULL)
+    start_line = Ref{Cuint}(0)
+    end_line = Ref{Cuint}(0)
+    start_column = Ref{Cuint}(0)
+    end_column = Ref{Cuint}(0)
+    offset = Ref{Cuint}(0)
+    clang_getExpansionLocation(range_start, file, start_line, start_column, offset)
+    clang_getExpansionLocation(range_end, file, end_line, end_column, offset)
+
+    expanded_start = clang_getLocation(tu, file[], start_line[], start_column[])
+    expanded_end = clang_getLocation(tu, file[], end_line[], end_column[])
+    expanded_range = clang_getRange(expanded_start, expanded_end)
+    return TokenList(tu, expanded_range)
 end
 tokenize(c::CLCursor) = tokenize(c.cursor)
 

--- a/test/c/macro.h
+++ b/test/c/macro.h
@@ -1,1 +1,8 @@
 #define G_URI_RESERVED_CHARS_SUBCOMPONENT_DELIMITERS "!$&'()*+,;="
+
+#define FOO(x, a, b) (a) <= (x) && (x) < (b)
+void macro_range(void) {
+    int foo = 1;
+    int x = 0;
+    x = FOO(foo, 1, x);
+}

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -4,8 +4,7 @@ using Test
 
 @testset "macro" begin
     trans_unit = parse_header(joinpath(@__DIR__, "c", "macro.h"),
-                              flags = CXTranslationUnit_DetailedPreprocessingRecord |
-                                      CXTranslationUnit_SkipFunctionBodies)
+                              flags = CXTranslationUnit_DetailedPreprocessingRecord)
     root_cursor = getcursor(trans_unit)
     cursors = children(root_cursor)
     g_uri_xxx = search(cursors, x->name(x)=="G_URI_RESERVED_CHARS_SUBCOMPONENT_DELIMITERS")[1]
@@ -14,4 +13,10 @@ using Test
     wrap!(ctx, g_uri_xxx)
     expr = :(const G_URI_RESERVED_CHARS_SUBCOMPONENT_DELIMITERS = "!\$&'()*+,;=")
     @test ctx.common_buffer[:G_URI_RESERVED_CHARS_SUBCOMPONENT_DELIMITERS].items[1] == expr
+    # test tokenize for macro instantiation
+    func = search(cursors, x->kind(x)==CXCursor_FunctionDecl)[1]
+    body = children(func)[1]
+    op = children(body)[3]
+    subop = children(op)[2]
+    @test mapreduce(x->x.text, *, tokenize(subop)) == "FOO(foo,1,x)"
 end


### PR DESCRIPTION
Before, tokenizing a macro will give us a wrong token range.